### PR TITLE
change to multi-stage build in Dockerfile and README update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,13 @@
+FROM alpine:latest AS client-builder
+
+RUN apk fix && \
+    apk --no-cache --update add git
+
+WORKDIR /tmp
+
+RUN git clone https://github.com/swagger-api/swagger-editor.git
+
+
 FROM scratch
 
 LABEL org.opencontainers.image.title="Swagger Editor" \
@@ -11,6 +21,6 @@ LABEL org.opencontainers.image.title="Swagger Editor" \
     com.docker.extension.additional-urls='[{"title":"Swagger","url":"https://swagger.io/"}]' \
     com.docker.extension.changelog=""
 
-COPY swagger-editor ./swagger-editor
+COPY --from=client-builder /tmp/swagger-editor ./swagger-editor
 COPY swagger.svg swagger.svg
 COPY metadata.json .

--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ mv docker-extension ~/.docker/cli-plugins
 
 If you want to build the extension locally then run the following:
 ```
-# clone a copy of the swagger-editor repository
-git clone https://github.com/swagger-api/swagger-editor.git
-
 # build the extension
 docker buildx build -t noelm/swagger-editor-extension:0.0.2 .
 


### PR DESCRIPTION
Updated the Dockerfile and now using multi-stage build to pull the swagger-editor repo (thank you @spurin for the feedback) and updated the README.md